### PR TITLE
Add kotlin support

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 26 23:06:06 MSK 2016
+#Sun Oct 23 22:01:18 JST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip

--- a/src/main/java/com/robohorse/robopojogenerator/generator/PostProcessorFactory.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/PostProcessorFactory.java
@@ -16,8 +16,17 @@ public class PostProcessorFactory {
     }
 
     public AbsPostProcessor createPostProcessor(GenerationModel generationModel) {
+
+        switch (generationModel.getLanguageItem()) {
+            case KOTLIN_DTO: {
+                return Injector.getAppComponent().newKotlinDataClassPostProcessor();
+            }
+        }
+
         switch (generationModel.getAnnotationItem()) {
             case AUTO_VALUE_GSON: {
+                // I disable AutoValue when select Kotlin
+                // So if the above is Kotlin, it won't get here
                 return Injector.getAppComponent().newAutoValueClassPostProcessor();
             }
             default: {

--- a/src/main/java/com/robohorse/robopojogenerator/generator/PostProcessorFactory.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/PostProcessorFactory.java
@@ -1,5 +1,8 @@
 package com.robohorse.robopojogenerator.generator;
 
+import com.robohorse.robopojogenerator.generator.consts.AnnotationItem;
+import com.robohorse.robopojogenerator.generator.consts.Imports;
+import com.robohorse.robopojogenerator.generator.consts.LanguageItem;
 import com.robohorse.robopojogenerator.generator.postprocessors.AbsPostProcessor;
 import com.robohorse.robopojogenerator.injections.Injector;
 import com.robohorse.robopojogenerator.models.GenerationModel;
@@ -17,16 +20,14 @@ public class PostProcessorFactory {
 
     public AbsPostProcessor createPostProcessor(GenerationModel generationModel) {
 
-        switch (generationModel.getLanguageItem()) {
-            case KOTLIN_DTO: {
-                return Injector.getAppComponent().newKotlinDataClassPostProcessor();
-            }
+        // Not support AutoValue yet
+        if (generationModel.getLanguageItem().equals(LanguageItem.KOTLIN_DTO)
+                && !generationModel.getAnnotationItem().equals(AnnotationItem.AUTO_VALUE_GSON)){
+            return Injector.getAppComponent().newKotlinDataClassPostProcessor();
         }
 
         switch (generationModel.getAnnotationItem()) {
             case AUTO_VALUE_GSON: {
-                // I disable AutoValue when select Kotlin
-                // So if the above is Kotlin, it won't get here
                 return Injector.getAppComponent().newAutoValueClassPostProcessor();
             }
             default: {

--- a/src/main/java/com/robohorse/robopojogenerator/generator/ProcessorFactory.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/ProcessorFactory.java
@@ -1,0 +1,30 @@
+package com.robohorse.robopojogenerator.generator;
+
+import com.robohorse.robopojogenerator.generator.processors.AbsClassProcessor;
+import com.robohorse.robopojogenerator.injections.Injector;
+import com.robohorse.robopojogenerator.models.GenerationModel;
+
+import javax.inject.Inject;
+
+/**
+ * This is the ProcessorFactory class
+ * Please put some info here.
+ *
+ * @author Wafer Li
+ * @since 16/10/24 21:43
+ */
+class ProcessorFactory {
+
+    @Inject
+    public ProcessorFactory() {
+
+    }
+
+    AbsClassProcessor createClassProcessor(GenerationModel generationModel) {
+        switch (generationModel.getLanguageItem()) {
+            default: {
+                return Injector.getAppComponent().newClassProcessor();
+            }
+        }
+    }
+}

--- a/src/main/java/com/robohorse/robopojogenerator/generator/RoboPOJOGenerator.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/RoboPOJOGenerator.java
@@ -1,12 +1,14 @@
 package com.robohorse.robopojogenerator.generator;
 
-import com.robohorse.robopojogenerator.generator.processors.ClassProcessor;
+import com.robohorse.robopojogenerator.generator.processors.AbsClassProcessor;
 import com.robohorse.robopojogenerator.models.GenerationModel;
+
 import org.json.JSONObject;
 
-import javax.inject.Inject;
 import java.util.HashSet;
 import java.util.Set;
+
+import javax.inject.Inject;
 
 
 /**
@@ -14,7 +16,7 @@ import java.util.Set;
  */
 public class RoboPOJOGenerator {
     @Inject
-    ClassProcessor classProcessor;
+    ProcessorFactory factory;
 
     @Inject
     public RoboPOJOGenerator() {
@@ -23,7 +25,8 @@ public class RoboPOJOGenerator {
     public Set<ClassItem> generate(GenerationModel model) {
         final Set<ClassItem> classItemSet = new HashSet<ClassItem>();
         final JSONObject jsonObject = new JSONObject(model.getContent());
-        classProcessor.proceed(jsonObject, model.getRootClassName(), classItemSet);
+        final AbsClassProcessor processor = factory.createClassProcessor(model);
+        processor.proceed(jsonObject, model.getRootClassName(), classItemSet);
         return classItemSet;
     }
 }

--- a/src/main/java/com/robohorse/robopojogenerator/generator/consts/ClassTemplate.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/consts/ClassTemplate.java
@@ -17,6 +17,11 @@ public interface ClassTemplate {
             "%2$s" + NEW_LINE +
             "}";
 
+    String CLASS_BODY_KOTLIN_DTO = "data class %1$s" +
+                                   "(" + NEW_LINE +
+                                   "%2$s" + NEW_LINE +
+                                   ")";
+
     String CLASS_BODY_ANNOTATED = "%1$s" + NEW_LINE +
             "%2$s";
 

--- a/src/main/java/com/robohorse/robopojogenerator/generator/consts/ClassTemplate.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/consts/ClassTemplate.java
@@ -4,18 +4,19 @@ package com.robohorse.robopojogenerator.generator.consts;
  * Created by vadim on 05.10.16.
  */
 public interface ClassTemplate {
+
     String NEW_LINE = "\n";
-    String TAB = "\t";
+    String TAB      = "\t";
 
     String CLASS_BODY = "public class %1$s" +
-            "{" + NEW_LINE +
-            "%2$s" + NEW_LINE +
-            "}";
+                        "{" + NEW_LINE +
+                        "%2$s" + NEW_LINE +
+                        "}";
 
     String CLASS_BODY_ABSTRACT = "public abstract class %1$s" +
-            "{" + NEW_LINE +
-            "%2$s" + NEW_LINE +
-            "}";
+                                 "{" + NEW_LINE +
+                                 "%2$s" + NEW_LINE +
+                                 "}";
 
     String CLASS_BODY_KOTLIN_DTO = "data class %1$s" +
                                    "(" + NEW_LINE +
@@ -23,14 +24,21 @@ public interface ClassTemplate {
                                    ")";
 
     String CLASS_BODY_ANNOTATED = "%1$s" + NEW_LINE +
-            "%2$s";
+                                  "%2$s";
 
     String CLASS_ROOT_IMPORTS = "package %1$s;" + NEW_LINE + NEW_LINE +
-            "%2$s" + NEW_LINE
-            + "%3$s";
+                                "%2$s" + NEW_LINE
+                                + "%3$s";
+
+    String CLASS_ROOT_IMPORTS_WITHOUT_SEMICOLON = "package %1$s" + NEW_LINE + NEW_LINE +
+                                                  "%2$s" + NEW_LINE
+                                                  + "%3$s";
 
     String CLASS_ROOT = "package %1$s;" + NEW_LINE + NEW_LINE +
-            "%2$s" + NEW_LINE;
+                        "%2$s" + NEW_LINE;
+
+    String CLASS_ROOT_WITHOUT_SEMICOLON = "package %1$s;" + NEW_LINE + NEW_LINE +
+                                          "%2$s" + NEW_LINE;
 
     String FIELD = TAB + "private %1$s %2$s;" + NEW_LINE;
 
@@ -42,19 +50,20 @@ public interface ClassTemplate {
 
     String FIELD_ANNOTATED = TAB + "%1$s" + NEW_LINE + "%2$s";
 
-    String TYPE_ADAPTER = TAB + "public static TypeAdapter<%1$s> typeAdapter(Gson gson) {" + NEW_LINE +
-            TAB + TAB + "return new AutoValue_%1$s.GsonTypeAdapter(gson);" + NEW_LINE
-            + TAB + "}" + NEW_LINE;
+    String TYPE_ADAPTER = TAB + "public static TypeAdapter<%1$s> typeAdapter(Gson gson) {" +
+                          NEW_LINE +
+                          TAB + TAB + "return new AutoValue_%1$s.GsonTypeAdapter(gson);" + NEW_LINE
+                          + TAB + "}" + NEW_LINE;
 
     String SETTER = TAB + "public void set%1$s(%2$s %3$s){" + NEW_LINE +
-            TAB + TAB + "this.%3$s = %3$s;" + NEW_LINE
-            + TAB + "}" + NEW_LINE;
+                    TAB + TAB + "this.%3$s = %3$s;" + NEW_LINE
+                    + TAB + "}" + NEW_LINE;
 
     String GETTER = TAB + "public %3$s get%1$s(){" + NEW_LINE +
-            TAB + TAB + "return %2$s;" + NEW_LINE
-            + TAB + "}" + NEW_LINE;
+                    TAB + TAB + "return %2$s;" + NEW_LINE
+                    + TAB + "}" + NEW_LINE;
 
     String GETTER_BOOLEAN = TAB + "public boolean is%1$s(){" + NEW_LINE +
-            TAB + TAB + "return %2$s;" + NEW_LINE
-            + TAB + "}" + NEW_LINE;
+                            TAB + TAB + "return %2$s;" + NEW_LINE
+                            + TAB + "}" + NEW_LINE;
 }

--- a/src/main/java/com/robohorse/robopojogenerator/generator/consts/ClassTemplate.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/consts/ClassTemplate.java
@@ -37,7 +37,7 @@ public interface ClassTemplate {
     String CLASS_ROOT = "package %1$s;" + NEW_LINE + NEW_LINE +
                         "%2$s" + NEW_LINE;
 
-    String CLASS_ROOT_WITHOUT_SEMICOLON = "package %1$s;" + NEW_LINE + NEW_LINE +
+    String CLASS_ROOT_WITHOUT_SEMICOLON = "package %1$s" + NEW_LINE + NEW_LINE +
                                           "%2$s" + NEW_LINE;
 
     String FIELD = TAB + "private %1$s %2$s;" + NEW_LINE;

--- a/src/main/java/com/robohorse/robopojogenerator/generator/consts/ClassTemplate.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/consts/ClassTemplate.java
@@ -36,7 +36,7 @@ public interface ClassTemplate {
 
     String FIELD_AUTO_VALUE = TAB + "public abstract %1$s %2$s();" + NEW_LINE;
 
-    String FIELD_KOTLIN_DTO = TAB + "val %1$s: %2$s?" + "," + NEW_LINE;
+    String FIELD_KOTLIN_DTO = TAB + "val %1$s: %2$s? = null" + "," + NEW_LINE;
 
     String FIELD_ANNOTATED = TAB + "%1$s" + NEW_LINE + "%2$s";
 

--- a/src/main/java/com/robohorse/robopojogenerator/generator/consts/ClassTemplate.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/consts/ClassTemplate.java
@@ -31,6 +31,8 @@ public interface ClassTemplate {
 
     String FIELD_AUTO_VALUE = TAB + "public abstract %1$s %2$s();" + NEW_LINE;
 
+    String FIELD_KOTLIN_DTO = TAB + "val %1$s: %2$s?" + "," + NEW_LINE;
+
     String FIELD_ANNOTATED = TAB + "%1$s" + NEW_LINE + "%2$s";
 
     String TYPE_ADAPTER = TAB + "public static TypeAdapter<%1$s> typeAdapter(Gson gson) {" + NEW_LINE +

--- a/src/main/java/com/robohorse/robopojogenerator/generator/consts/ClassTemplate.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/consts/ClassTemplate.java
@@ -38,6 +38,8 @@ public interface ClassTemplate {
 
     String FIELD_KOTLIN_DTO = TAB + "val %1$s: %2$s? = null" + "," + NEW_LINE;
 
+    String FIELD_KOTLIN_DOT_DEFAULT = TAB + "val any: Any? = null";
+
     String FIELD_ANNOTATED = TAB + "%1$s" + NEW_LINE + "%2$s";
 
     String TYPE_ADAPTER = TAB + "public static TypeAdapter<%1$s> typeAdapter(Gson gson) {" + NEW_LINE +

--- a/src/main/java/com/robohorse/robopojogenerator/generator/consts/LanguageItem.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/consts/LanguageItem.java
@@ -1,0 +1,26 @@
+package com.robohorse.robopojogenerator.generator.consts;
+
+/**
+ * This is the LanguageItem class
+ * Please put some info here.
+ *
+ * @author Wafer Li
+ * @since 16/10/23 23:50
+ */
+public enum LanguageItem {
+
+    POJO("Java POJO"),
+    KOTLIN_DTO("Kotlin DTO");
+
+    private String text;
+
+    LanguageItem(String text) {
+        this.text = text;
+    }
+
+
+    public String getText() {
+
+        return text;
+    }
+}

--- a/src/main/java/com/robohorse/robopojogenerator/generator/consts/annotations/KotlinAnnotations.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/consts/annotations/KotlinAnnotations.java
@@ -1,0 +1,27 @@
+package com.robohorse.robopojogenerator.generator.consts.annotations;
+
+/**
+ * This is the KotlinAnnotations class
+ * Please put some info here.
+ *
+ * @author Wafer Li
+ * @since 16/10/24 21:07
+ */
+public interface KotlinAnnotations {
+    String INFO_ANNOTATION = "@Generated(\"com.robohorse.robopojogenerator\")";
+
+    interface GSON {
+        String CLASS_ANNOTATION = INFO_ANNOTATION;
+        String ANNOTATION = "@field:SerializedName(\"%1$s\")\n\t@field:Expose";
+    }
+
+    interface LOGAN_SQUARE {
+        String CLASS_ANNOTATION = INFO_ANNOTATION + "\n@JsonObject";
+        String ANNOTATION = "@field:SerializedName(\"%1$s\")\n\t@field:JsonField(name =\"%1$s\")";
+    }
+
+    interface JACKSON {
+        String CLASS_ANNOTATION = INFO_ANNOTATION;
+        String ANNOTATION = "@field:JsonProperty(\"%1$s\")";
+    }
+}

--- a/src/main/java/com/robohorse/robopojogenerator/generator/consts/annotations/PojoAnnotations.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/consts/annotations/PojoAnnotations.java
@@ -1,4 +1,4 @@
-package com.robohorse.robopojogenerator.generator.consts;
+package com.robohorse.robopojogenerator.generator.consts.annotations;
 
 /**
  * Created by vadim on 02.10.16.

--- a/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/AbsPostProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/AbsPostProcessor.java
@@ -10,69 +10,87 @@ import com.robohorse.robopojogenerator.generator.utils.ClassGenerateHelper;
 import com.robohorse.robopojogenerator.models.GenerationModel;
 
 import javax.inject.Inject;
+
 import java.util.Set;
 
 /**
  * Created by vadim on 23.10.16.
  */
 public abstract class AbsPostProcessor {
+
     @Inject
-    ClassGenerateHelper generateHelper;
+    ClassGenerateHelper    generateHelper;
     @Inject
     ClassTemplateProcessor classTemplateProcessor;
 
+
     public String proceed(ClassItem classItem, GenerationModel generationModel) {
+
         applyAnnotations(generationModel.getAnnotationItem(), classItem);
         return proceedClass(classItem, generationModel);
     }
+
 
     public abstract String proceedClassBody(ClassItem classItem, GenerationModel generationModel);
 
     public abstract String createClassTemplate(ClassItem classItem, String classBody);
 
+
     private String proceedClass(ClassItem classItem, GenerationModel generationModel) {
-        final String classBody = proceedClassBody(classItem, generationModel);
-        final String classTemplate = createClassTemplate(classItem, classBody);
-        final Set<String> imports = classItem.getClassImports();
+
+        final String        classBody      = proceedClassBody(classItem, generationModel);
+        final String        classTemplate  = createClassTemplate(classItem, classBody);
+        final Set<String>   imports        = classItem.getClassImports();
         final StringBuilder importsBuilder = new StringBuilder();
         for (String importItem : imports) {
             importsBuilder.append(importItem);
             importsBuilder.append(ClassTemplate.NEW_LINE);
         }
+
+        return createClassItemText(classItem.getPackagePath(),
+                                   importsBuilder.toString(),
+                                   classTemplate);
+    }
+
+
+    protected String createClassItemText(String packagePath, String imports, String classTemplate) {
+
         return classTemplateProcessor.createClassItem(
-                classItem.getPackagePath(),
-                importsBuilder.toString(),
+                packagePath,
+                imports,
                 classTemplate);
     }
 
+
     private void applyAnnotations(AnnotationItem item, ClassItem classItem) {
+
         switch (item) {
             case GSON: {
                 generateHelper.setAnnotations(classItem,
-                        PojoAnnotations.GSON.CLASS_ANNOTATION,
-                        PojoAnnotations.GSON.ANNOTATION,
-                        Imports.GSON.IMPORTS);
+                                              PojoAnnotations.GSON.CLASS_ANNOTATION,
+                                              PojoAnnotations.GSON.ANNOTATION,
+                                              Imports.GSON.IMPORTS);
                 break;
             }
             case LOGAN_SQUARE: {
                 generateHelper.setAnnotations(classItem,
-                        PojoAnnotations.LOGAN_SQUARE.CLASS_ANNOTATION,
-                        PojoAnnotations.LOGAN_SQUARE.ANNOTATION,
-                        Imports.LOGAN_SQUARE.IMPORTS);
+                                              PojoAnnotations.LOGAN_SQUARE.CLASS_ANNOTATION,
+                                              PojoAnnotations.LOGAN_SQUARE.ANNOTATION,
+                                              Imports.LOGAN_SQUARE.IMPORTS);
                 break;
             }
             case JACKSON: {
                 generateHelper.setAnnotations(classItem,
-                        PojoAnnotations.JACKSON.CLASS_ANNOTATION,
-                        PojoAnnotations.JACKSON.ANNOTATION,
-                        Imports.JACKSON.IMPORTS);
+                                              PojoAnnotations.JACKSON.CLASS_ANNOTATION,
+                                              PojoAnnotations.JACKSON.ANNOTATION,
+                                              Imports.JACKSON.IMPORTS);
                 break;
             }
             case AUTO_VALUE_GSON: {
                 generateHelper.setAnnotations(classItem,
-                        PojoAnnotations.AUTO_VALUE_GSON.CLASS_ANNOTATION,
-                        PojoAnnotations.AUTO_VALUE_GSON.ANNOTATION,
-                        Imports.AUTO_VALUE_GSON.IMPORTS);
+                                              PojoAnnotations.AUTO_VALUE_GSON.CLASS_ANNOTATION,
+                                              PojoAnnotations.AUTO_VALUE_GSON.ANNOTATION,
+                                              Imports.AUTO_VALUE_GSON.IMPORTS);
                 break;
             }
         }

--- a/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/AbsPostProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/AbsPostProcessor.java
@@ -4,7 +4,7 @@ import com.robohorse.robopojogenerator.generator.ClassItem;
 import com.robohorse.robopojogenerator.generator.consts.AnnotationItem;
 import com.robohorse.robopojogenerator.generator.consts.ClassTemplate;
 import com.robohorse.robopojogenerator.generator.consts.Imports;
-import com.robohorse.robopojogenerator.generator.consts.PojoAnnotations;
+import com.robohorse.robopojogenerator.generator.consts.annotations.PojoAnnotations;
 import com.robohorse.robopojogenerator.generator.processors.ClassTemplateProcessor;
 import com.robohorse.robopojogenerator.generator.utils.ClassGenerateHelper;
 import com.robohorse.robopojogenerator.models.GenerationModel;
@@ -62,7 +62,7 @@ public abstract class AbsPostProcessor {
     }
 
 
-    private void applyAnnotations(AnnotationItem item, ClassItem classItem) {
+    protected void applyAnnotations(AnnotationItem item, ClassItem classItem) {
 
         switch (item) {
             case GSON: {

--- a/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
@@ -114,7 +114,7 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
         if (matcher.find()) {
             // Type is List
 
-            innerType = generateHelper.upperCaseFirst(matcher.group(0));
+            innerType = generateHelper.upperCaseFirst(matcher.group(1));
 
             if (innerType.equals(ClassType.OBJECT.getBoxed())) {
                 innerType = "Any";
@@ -123,7 +123,7 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
                 innerType = "Int";
             }
 
-            type = type.replaceAll(regex, innerType);
+            type = type.replaceAll(regex, "<" + innerType + ">");
             type = type.replaceAll(">", "?>");
         }
         else {

--- a/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
@@ -1,11 +1,12 @@
 package com.robohorse.robopojogenerator.generator.postprocessors;
 
 import com.google.common.base.CaseFormat;
-import com.google.gson.annotations.SerializedName;
 import com.robohorse.robopojogenerator.generator.ClassItem;
+import com.robohorse.robopojogenerator.generator.consts.AnnotationItem;
 import com.robohorse.robopojogenerator.generator.consts.ClassTemplate;
 import com.robohorse.robopojogenerator.generator.consts.ClassType;
 import com.robohorse.robopojogenerator.generator.consts.Imports;
+import com.robohorse.robopojogenerator.generator.consts.annotations.KotlinAnnotations;
 import com.robohorse.robopojogenerator.models.GenerationModel;
 
 import java.util.HashSet;
@@ -42,7 +43,7 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
         for (String objectName : classFields.keySet()) {
 
             String type       = proceedType(classFields.get(objectName));
-            String annotation = proceedAnnotation(classItem.getAnnotation());
+            String annotation = classItem.getAnnotation();
             String fieldName  = proceedField(objectName);
 
             classBodyBuilder.append(
@@ -96,19 +97,32 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
     }
 
 
-    private String proceedAnnotation(String annotation) {
+    @Override
+    protected void applyAnnotations(AnnotationItem item, ClassItem classItem) {
 
-        if (annotation != null) {
-            String regex = "\"@(.+?)\"";
-            annotation = annotation.replaceAll(regex, "\"ç$1\"");
-            annotation = annotation.replaceAll("@", "@field:");
-
-            regex = "\"ç(.+?)\"";
-            annotation = annotation.replaceAll(regex, "\"@$1\"");
-
-            return annotation;
+        switch (item) {
+            case GSON: {
+                generateHelper.setAnnotations(classItem,
+                                              KotlinAnnotations.GSON.CLASS_ANNOTATION,
+                                              KotlinAnnotations.GSON.ANNOTATION,
+                                              Imports.GSON.IMPORTS);
+                break;
+            }
+            case LOGAN_SQUARE: {
+                generateHelper.setAnnotations(classItem,
+                                              KotlinAnnotations.LOGAN_SQUARE.CLASS_ANNOTATION,
+                                              KotlinAnnotations.LOGAN_SQUARE.ANNOTATION,
+                                              Imports.LOGAN_SQUARE.IMPORTS);
+                break;
+            }
+            case JACKSON: {
+                generateHelper.setAnnotations(classItem,
+                                              KotlinAnnotations.JACKSON.CLASS_ANNOTATION,
+                                              KotlinAnnotations.JACKSON.ANNOTATION,
+                                              Imports.JACKSON.IMPORTS);
+                break;
+            }
         }
-        return null;
     }
 
 

--- a/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
@@ -68,7 +68,6 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
 
     @Override
     public String createClassTemplate(ClassItem classItem, String classBody) {
-
-        return null;
+        return classTemplateProcessor.createClassBodyKotlinDataClass(classItem, classBody);
     }
 }

--- a/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
@@ -97,7 +97,10 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
 
     private String proceedAnnotation(String annotation) {
 
-        return annotation.replaceAll("@", "@field:");
+        if (annotation != null) {
+            return annotation.replaceAll("@", "@field:");
+        }
+        return null;
     }
 
 
@@ -120,7 +123,7 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
                 innerType = "Int";
             }
 
-            type = type.replaceAll(regex, "<" + innerType + ">");
+            type = type.replaceAll(regex, innerType);
             type = type.replaceAll(">", "?>");
         }
         else {

--- a/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
@@ -1,6 +1,7 @@
 package com.robohorse.robopojogenerator.generator.postprocessors;
 
 import com.google.common.base.CaseFormat;
+import com.google.gson.annotations.SerializedName;
 import com.robohorse.robopojogenerator.generator.ClassItem;
 import com.robohorse.robopojogenerator.generator.consts.ClassTemplate;
 import com.robohorse.robopojogenerator.generator.consts.ClassType;
@@ -98,7 +99,14 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
     private String proceedAnnotation(String annotation) {
 
         if (annotation != null) {
-            return annotation.replaceAll("@", "@field:");
+            String regex = "\"@(.+?)\"";
+            annotation = annotation.replaceAll(regex, "\"ç$1\"");
+            annotation = annotation.replaceAll("@", "@field:");
+
+            regex = "\"ç(.+?)\"";
+            annotation = annotation.replaceAll(regex, "\"@$1\"");
+
+            return annotation;
         }
         return null;
     }

--- a/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
@@ -29,6 +29,7 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
 
     }
 
+
     @Override
     public String proceedClassBody(ClassItem classItem, GenerationModel generationModel) {
 
@@ -107,7 +108,7 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
         final Matcher matcher = pattern.matcher(type);
 
         String innerType;
-        if (matcher.groupCount() != 0) {
+        if (matcher.find()) {
             // Type is List
 
             innerType = generateHelper.upperCaseFirst(matcher.group(0));

--- a/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
@@ -3,6 +3,7 @@ package com.robohorse.robopojogenerator.generator.postprocessors;
 import com.robohorse.robopojogenerator.generator.ClassItem;
 import com.robohorse.robopojogenerator.generator.consts.ClassTemplate;
 import com.robohorse.robopojogenerator.generator.consts.ClassType;
+import com.robohorse.robopojogenerator.generator.consts.Imports;
 import com.robohorse.robopojogenerator.models.GenerationModel;
 
 import java.util.HashSet;
@@ -23,7 +24,7 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
     @Override
     public String proceedClassBody(ClassItem classItem, GenerationModel generationModel) {
 
-        removeClassImportSemicolon(classItem);
+        proceedImports(classItem);
 
         StringBuilder       classBodyBuilder = new StringBuilder();
         Map<String, String> classFields      = classItem.getClassFields();
@@ -102,13 +103,23 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
     }
 
 
-    private void removeClassImportSemicolon(ClassItem classItem) {
+    /**
+     * Remove List import and semicolon
+     * @param classItem The class item which is use to getting import
+     */
+    private void proceedImports(ClassItem classItem) {
 
         Set<String> classImports = classItem.getClassImports();
 
         Set<String> classImportWithoutSemicolon = new HashSet<String>();
 
         for (String classImport : classImports) {
+
+            if (classImport.equals(Imports.LIST)) {
+                // Kotlin don't use List import
+                continue;
+            }
+
             classImport = classImport.substring(0, classImport.indexOf(";"));
             classImportWithoutSemicolon.add(classImport);
         }

--- a/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jdk.nashorn.internal.runtime.regexp.joni.encoding.CharacterType;
+import javax.inject.Inject;
 
 /**
  * This is the KotlinDataClassPostProcessor class
@@ -23,6 +23,11 @@ import jdk.nashorn.internal.runtime.regexp.joni.encoding.CharacterType;
  * @since 16/10/24 00:30
  */
 public class KotlinDataClassPostProcessor extends AbsPostProcessor {
+
+    @Inject
+    public KotlinDataClassPostProcessor() {
+
+    }
 
     @Override
     public String proceedClassBody(ClassItem classItem, GenerationModel generationModel) {

--- a/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
@@ -46,7 +46,7 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
 
             classBodyBuilder.append(
                     classTemplateProcessor
-                            .createKotlinDataClassField(type, fieldName, annotation));
+                            .createKotlinDataClassField(type, fieldName, objectName, annotation));
         }
 
         if (classBodyBuilder.length() == 0) {

--- a/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
@@ -1,6 +1,7 @@
 package com.robohorse.robopojogenerator.generator.postprocessors;
 
 import com.robohorse.robopojogenerator.generator.ClassItem;
+import com.robohorse.robopojogenerator.generator.consts.ClassTemplate;
 import com.robohorse.robopojogenerator.generator.consts.ClassType;
 import com.robohorse.robopojogenerator.models.GenerationModel;
 
@@ -35,6 +36,15 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
             classBodyBuilder.append(
                     classTemplateProcessor
                             .createKotlinDataClassField(type, objectName, annotation));
+        }
+
+        if (classBodyBuilder.length() == 0) {
+            // Kotlin don't allow empty constructor
+            classBodyBuilder.append(ClassTemplate.FIELD_KOTLIN_DOT_DEFAULT);
+        }
+        else {
+            // Remove the last comma
+            classBodyBuilder.deleteCharAt(classBodyBuilder.lastIndexOf(","));
         }
 
         return classBodyBuilder.toString();

--- a/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
@@ -1,0 +1,74 @@
+package com.robohorse.robopojogenerator.generator.postprocessors;
+
+import com.robohorse.robopojogenerator.generator.ClassItem;
+import com.robohorse.robopojogenerator.models.GenerationModel;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This is the KotlinDataClassPostProcessor class
+ * Please put some info here.
+ *
+ * @author Wafer Li
+ * @since 16/10/24 00:30
+ */
+public class KotlinDataClassPostProcessor extends AbsPostProcessor {
+
+    @Override
+    public String proceedClassBody(ClassItem classItem, GenerationModel generationModel) {
+
+        removeClassImportSemicolon(classItem);
+
+        StringBuilder       classBodyBuilder = new StringBuilder();
+        Map<String, String> classFields      = classItem.getClassFields();
+
+        for (String objectName : classFields.keySet()) {
+
+            String type = proceedType(classFields.get(objectName));
+            String annotation = proceedAnnotation(classItem.getAnnotation());
+
+            classBodyBuilder.append(
+                    classTemplateProcessor
+                            .createKotlinDataClassField(type, objectName, annotation));
+        }
+
+        return classBodyBuilder.toString();
+    }
+
+
+    private String proceedAnnotation(String annotation) {
+        return annotation.replaceAll("@", "@field:");
+    }
+
+
+    private String proceedType(String type) {
+
+        type = type.replaceAll("Object", "Any");
+        return type.replaceAll(">", "?>");
+    }
+
+
+    private void removeClassImportSemicolon(ClassItem classItem) {
+
+        Set<String> classImports = classItem.getClassImports();
+
+        Set<String> classImportWithoutSemicolon = new HashSet<String>();
+
+        for (String classImport : classImports) {
+            classImport = classImport.substring(0, classImport.indexOf(";"));
+            classImportWithoutSemicolon.add(classImport);
+        }
+
+        classImports.clear();
+        classImports.addAll(classImportWithoutSemicolon);
+    }
+
+
+    @Override
+    public String createClassTemplate(ClassItem classItem, String classBody) {
+
+        return null;
+    }
+}

--- a/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/postprocessors/KotlinDataClassPostProcessor.java
@@ -51,6 +51,15 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
     }
 
 
+    @Override
+    protected String createClassItemText(String packagePath, String imports, String classTemplate) {
+
+        return classTemplateProcessor.createClassItemWithoutSemicolon(packagePath,
+                                                                      imports,
+                                                                      classTemplate);
+    }
+
+
     private String proceedAnnotation(String annotation) {
 
         return annotation.replaceAll("@", "@field:");
@@ -59,7 +68,7 @@ public class KotlinDataClassPostProcessor extends AbsPostProcessor {
 
     private String proceedType(String type) {
 
-        final String regex = "<([^<>]*)>";
+        final String  regex   = "<([^<>]*)>";
         final Pattern pattern = Pattern.compile(regex);
         final Matcher matcher = pattern.matcher(type);
 

--- a/src/main/java/com/robohorse/robopojogenerator/generator/processors/AbsClassProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/processors/AbsClassProcessor.java
@@ -1,0 +1,26 @@
+package com.robohorse.robopojogenerator.generator.processors;
+
+import com.robohorse.robopojogenerator.generator.ClassItem;
+import com.robohorse.robopojogenerator.generator.utils.ClassGenerateHelper;
+
+import org.json.JSONObject;
+
+import java.util.Set;
+
+import javax.inject.Inject;
+
+/**
+ * This is the AbsClassProcessor class
+ * Please put some info here.
+ *
+ * @author Wafer Li
+ * @since 16/10/24 21:35
+ */
+public abstract class AbsClassProcessor {
+    @Inject
+    ClassGenerateHelper classGenerateHelper;
+
+    public abstract void proceed(JSONObject jsonObject,
+                                 String className,
+                                 final Set<ClassItem> classItemSet);
+}

--- a/src/main/java/com/robohorse/robopojogenerator/generator/processors/ClassProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/processors/ClassProcessor.java
@@ -16,14 +16,13 @@ import java.util.Set;
 /**
  * Created by vadim on 23.09.16.
  */
-public class ClassProcessor {
-    @Inject
-    ClassGenerateHelper classGenerateHelper;
+public class ClassProcessor extends AbsClassProcessor{
 
     @Inject
     public ClassProcessor() {
     }
 
+    @Override
     public void proceed(JSONObject jsonObject, String className, final Set<ClassItem> classItemSet) {
         final ClassItem classItem = new ClassItem(classGenerateHelper.getClassName(className));
         for (final String jsonObjectKey : jsonObject.keySet()) {

--- a/src/main/java/com/robohorse/robopojogenerator/generator/processors/ClassTemplateProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/processors/ClassTemplateProcessor.java
@@ -47,11 +47,11 @@ public class ClassTemplateProcessor {
         return createAnnotatedField(name, annotation, field);
     }
 
-    public String createKotlinDataClassField(String type, String name, String annotation) {
+    public String createKotlinDataClassField(String type, String fieldName, String objectName, String annotation) {
         final String field = String.format(ClassTemplate.FIELD_KOTLIN_DTO,
-                                           classGenerateHelper.getClassField(name),
+                                           classGenerateHelper.getClassField(fieldName),
                                            type);
-        return createAnnotatedField(name, annotation, field);
+        return createAnnotatedField(objectName, annotation, field);
     }
 
     public String createClassBody(ClassItem classItem, String classBody) {

--- a/src/main/java/com/robohorse/robopojogenerator/generator/processors/ClassTemplateProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/processors/ClassTemplateProcessor.java
@@ -47,6 +47,13 @@ public class ClassTemplateProcessor {
         return createAnnotatedField(name, annotation, field);
     }
 
+    public String createKotlinDataClassField(String type, String name, String annotation) {
+        final String field = String.format(ClassTemplate.FIELD_KOTLIN_DTO,
+                                           classGenerateHelper.getClassField(name),
+                                           type);
+        return createAnnotatedField(name, annotation, field);
+    }
+
     public String createClassBody(ClassItem classItem, String classBody) {
         final String classItemBody = String.format(ClassTemplate.CLASS_BODY,
                 classItem.getClassName(),

--- a/src/main/java/com/robohorse/robopojogenerator/generator/processors/ClassTemplateProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/processors/ClassTemplateProcessor.java
@@ -72,6 +72,14 @@ public class ClassTemplateProcessor {
         return createClassBodyAnnotated(classItem, classItemBody);
     }
 
+    public String createClassBodyKotlinDataClass(ClassItem classItem, String classBody) {
+        final String classItemBody = String.format(ClassTemplate.CLASS_BODY_KOTLIN_DTO,
+                                                   classItem.getClassName(),
+                                                   classBody);
+
+        return createClassBodyAnnotated(classItem, classItemBody);
+    }
+
     public String createClassItem(String packagePath, String imports, String body) {
         if (null != imports && !imports.isEmpty()) {
             return String.format(ClassTemplate.CLASS_ROOT_IMPORTS,

--- a/src/main/java/com/robohorse/robopojogenerator/generator/processors/ClassTemplateProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/processors/ClassTemplateProcessor.java
@@ -93,6 +93,19 @@ public class ClassTemplateProcessor {
         }
     }
 
+    public String createClassItemWithoutSemicolon(String packagePath, String imports, String body) {
+        if (null != imports && !imports.isEmpty()) {
+            return String.format(ClassTemplate.CLASS_ROOT_IMPORTS_WITHOUT_SEMICOLON,
+                    packagePath,
+                    imports,
+                    body);
+        } else {
+            return String.format(ClassTemplate.CLASS_ROOT_WITHOUT_SEMICOLON,
+                    packagePath,
+                    body);
+        }
+    }
+
     private String createClassBodyAnnotated(ClassItem classItem, String classItemBody) {
         final String classAnnotation = classItem.getClassAnnotation();
         if (null != classAnnotation && !classAnnotation.isEmpty()) {

--- a/src/main/java/com/robohorse/robopojogenerator/injections/AppComponent.java
+++ b/src/main/java/com/robohorse/robopojogenerator/injections/AppComponent.java
@@ -3,6 +3,7 @@ package com.robohorse.robopojogenerator.injections;
 import com.robohorse.robopojogenerator.actions.GeneratePOJOAction;
 import com.robohorse.robopojogenerator.generator.postprocessors.AutoValueClassPostProcessor;
 import com.robohorse.robopojogenerator.generator.postprocessors.ClassPostProcessor;
+import com.robohorse.robopojogenerator.generator.postprocessors.KotlinDataClassPostProcessor;
 import com.robohorse.robopojogenerator.listeners.GenerateActionListener;
 import dagger.Component;
 
@@ -25,4 +26,5 @@ public interface AppComponent {
 
     AutoValueClassPostProcessor newAutoValueClassPostProcessor();
 
+    KotlinDataClassPostProcessor newKotlinDataClassPostProcessor();
 }

--- a/src/main/java/com/robohorse/robopojogenerator/injections/AppComponent.java
+++ b/src/main/java/com/robohorse/robopojogenerator/injections/AppComponent.java
@@ -4,6 +4,7 @@ import com.robohorse.robopojogenerator.actions.GeneratePOJOAction;
 import com.robohorse.robopojogenerator.generator.postprocessors.AutoValueClassPostProcessor;
 import com.robohorse.robopojogenerator.generator.postprocessors.ClassPostProcessor;
 import com.robohorse.robopojogenerator.generator.postprocessors.KotlinDataClassPostProcessor;
+import com.robohorse.robopojogenerator.generator.processors.ClassProcessor;
 import com.robohorse.robopojogenerator.listeners.GenerateActionListener;
 import dagger.Component;
 
@@ -21,6 +22,8 @@ public interface AppComponent {
     void inject(GeneratePOJOAction item);
 
     void inject(GenerateActionListener item);
+
+    ClassProcessor newClassProcessor();
 
     ClassPostProcessor newClassPostProcessor();
 

--- a/src/main/java/com/robohorse/robopojogenerator/listeners/GenerateActionListener.java
+++ b/src/main/java/com/robohorse/robopojogenerator/listeners/GenerateActionListener.java
@@ -1,7 +1,9 @@
 package com.robohorse.robopojogenerator.listeners;
 
+import com.intellij.codeInspection.javaDoc.JavadocHtmlLintAnnotator;
 import com.robohorse.robopojogenerator.errors.RoboPluginException;
 import com.robohorse.robopojogenerator.generator.consts.AnnotationItem;
+import com.robohorse.robopojogenerator.generator.consts.LanguageItem;
 import com.robohorse.robopojogenerator.generator.utils.ClassGenerateHelper;
 import com.robohorse.robopojogenerator.injections.Injector;
 import com.robohorse.robopojogenerator.models.GenerationModel;
@@ -37,6 +39,7 @@ public class GenerateActionListener implements ActionListener {
         final JTextArea textArea = generatorVew.getTextArea();
         final JTextField textField = generatorVew.getClassNameTextField();
 
+        final LanguageItem languageItem = resolveLanguageItem();
         final AnnotationItem annotationItem = resolveAnnotationItem();
         final boolean rewriteClasses = generatorVew.getRewriteExistingClassesCheckBox().isSelected();
         final boolean useSetters = generatorVew.getUseSettersCheckBox().isSelected();
@@ -48,6 +51,7 @@ public class GenerateActionListener implements ActionListener {
             classGenerateHelper.validateJsonContent(content);
             eventListener.onJsonDataObtained(new GenerationModel
                     .Builder()
+                    .setLanguageItem(languageItem)
                     .setAnnotationItem(annotationItem)
                     .setContent(content)
                     .setSettersAvailable(useSetters)
@@ -60,6 +64,25 @@ public class GenerateActionListener implements ActionListener {
             messageService.onPluginExceptionHandled(exception);
         }
     }
+
+
+    private LanguageItem resolveLanguageItem() {
+        final ButtonGroup buttonGroup = generatorVew.getLanguageGroup();
+
+        for (Enumeration<AbstractButton> buttons = buttonGroup.getElements(); buttons.hasMoreElements();) {
+            final AbstractButton button = buttons.nextElement();
+            if (button.isSelected()) {
+                for (LanguageItem languageItem : LanguageItem.values()) {
+                    if (languageItem.getText().equals(button.getText())) {
+                        return languageItem;
+                    }
+                }
+            }
+        }
+
+        return LanguageItem.POJO;
+    }
+
 
     private AnnotationItem resolveAnnotationItem() {
         final ButtonGroup buttonGroup = generatorVew.getTypeButtonGroup();

--- a/src/main/java/com/robohorse/robopojogenerator/listeners/GenerateActionListener.java
+++ b/src/main/java/com/robohorse/robopojogenerator/listeners/GenerateActionListener.java
@@ -4,6 +4,7 @@ import com.intellij.codeInspection.javaDoc.JavadocHtmlLintAnnotator;
 import com.robohorse.robopojogenerator.errors.RoboPluginException;
 import com.robohorse.robopojogenerator.generator.consts.AnnotationItem;
 import com.robohorse.robopojogenerator.generator.consts.LanguageItem;
+import com.robohorse.robopojogenerator.generator.postprocessors.AbsPostProcessor;
 import com.robohorse.robopojogenerator.generator.utils.ClassGenerateHelper;
 import com.robohorse.robopojogenerator.injections.Injector;
 import com.robohorse.robopojogenerator.models.GenerationModel;
@@ -12,6 +13,7 @@ import com.robohorse.robopojogenerator.view.GeneratorVew;
 
 import javax.inject.Inject;
 import javax.swing.*;
+
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Enumeration;
@@ -20,45 +22,55 @@ import java.util.Enumeration;
  * Created by vadim on 24.09.16.
  */
 public class GenerateActionListener implements ActionListener {
+
     @Inject
-    MessageService messageService;
+    MessageService      messageService;
     @Inject
     ClassGenerateHelper classGenerateHelper;
 
     private GuiFormEventListener eventListener;
-    private GeneratorVew generatorVew;
+    private GeneratorVew         generatorVew;
+
 
     public GenerateActionListener(GeneratorVew generatorVew,
                                   GuiFormEventListener eventListener) {
+
         this.generatorVew = generatorVew;
         this.eventListener = eventListener;
         Injector.getAppComponent().inject(this);
     }
 
+
     public void actionPerformed(ActionEvent e) {
-        final JTextArea textArea = generatorVew.getTextArea();
+
+        final JTextArea  textArea  = generatorVew.getTextArea();
         final JTextField textField = generatorVew.getClassNameTextField();
 
         final LanguageItem languageItem = resolveLanguageItem();
+        changeAnnotation(languageItem);
+
         final AnnotationItem annotationItem = resolveAnnotationItem();
-        final boolean rewriteClasses = generatorVew.getRewriteExistingClassesCheckBox().isSelected();
+
+        final boolean rewriteClasses = generatorVew.getRewriteExistingClassesCheckBox()
+                .isSelected();
         final boolean useSetters = generatorVew.getUseSettersCheckBox().isSelected();
         final boolean useGetters = generatorVew.getUseGettersCheckBox().isSelected();
-        final String content = textArea.getText();
+
+        final String content   = textArea.getText();
         final String className = textField.getText();
         try {
             classGenerateHelper.validateClassName(className);
             classGenerateHelper.validateJsonContent(content);
             eventListener.onJsonDataObtained(new GenerationModel
                     .Builder()
-                    .setLanguageItem(languageItem)
-                    .setAnnotationItem(annotationItem)
-                    .setContent(content)
-                    .setSettersAvailable(useSetters)
-                    .setGettersAvailable(useGetters)
-                    .setRootClassName(className)
-                    .setRewriteClasses(rewriteClasses)
-                    .build());
+                                                     .setLanguageItem(languageItem)
+                                                     .setAnnotationItem(annotationItem)
+                                                     .setContent(content)
+                                                     .setSettersAvailable(useSetters)
+                                                     .setGettersAvailable(useGetters)
+                                                     .setRootClassName(className)
+                                                     .setRewriteClasses(rewriteClasses)
+                                                     .build());
 
         } catch (RoboPluginException exception) {
             messageService.onPluginExceptionHandled(exception);
@@ -66,10 +78,47 @@ public class GenerateActionListener implements ActionListener {
     }
 
 
+    /**
+     * Disable autovalue when select Kotlin
+     *
+     * @param languageItem The selected language item
+     */
+    private void changeAnnotation(LanguageItem languageItem) {
+
+        ButtonGroup                 buttonGroup = generatorVew.getTypeButtonGroup();
+        Enumeration<AbstractButton> buttons     = buttonGroup.getElements();
+
+        if (languageItem.equals(LanguageItem.KOTLIN_DTO)) {
+            while (buttons.hasMoreElements()) {
+                final AbstractButton button = buttons.nextElement();
+
+                if (button.getText().contains("AutoValue")) {
+                    button.setSelected(false);
+                    button.setEnabled(false);
+                }
+                else if (button.getText().equals(AnnotationItem.NONE.getText())) {
+                    button.setSelected(true);
+                }
+            }
+        }
+        else {
+            while (buttons.hasMoreElements()) {
+                final AbstractButton button = buttons.nextElement();
+
+                if (!button.isEnabled()) {
+                    button.setEnabled(true);
+                }
+            }
+        }
+    }
+
+
     private LanguageItem resolveLanguageItem() {
+
         final ButtonGroup buttonGroup = generatorVew.getLanguageGroup();
 
-        for (Enumeration<AbstractButton> buttons = buttonGroup.getElements(); buttons.hasMoreElements();) {
+        for (Enumeration<AbstractButton> buttons = buttonGroup.getElements(); buttons
+                .hasMoreElements(); ) {
             final AbstractButton button = buttons.nextElement();
             if (button.isSelected()) {
                 for (LanguageItem languageItem : LanguageItem.values()) {
@@ -85,8 +134,10 @@ public class GenerateActionListener implements ActionListener {
 
 
     private AnnotationItem resolveAnnotationItem() {
+
         final ButtonGroup buttonGroup = generatorVew.getTypeButtonGroup();
-        for (Enumeration<AbstractButton> buttons = buttonGroup.getElements(); buttons.hasMoreElements(); ) {
+        for (Enumeration<AbstractButton> buttons = buttonGroup.getElements(); buttons
+                .hasMoreElements(); ) {
             final AbstractButton button = buttons.nextElement();
             if (button.isSelected()) {
                 for (AnnotationItem annotationItem : AnnotationItem.values()) {

--- a/src/main/java/com/robohorse/robopojogenerator/listeners/GenerateActionListener.java
+++ b/src/main/java/com/robohorse/robopojogenerator/listeners/GenerateActionListener.java
@@ -48,7 +48,6 @@ public class GenerateActionListener implements ActionListener {
         final JTextField textField = generatorVew.getClassNameTextField();
 
         final LanguageItem languageItem = resolveLanguageItem();
-        changeAnnotation(languageItem);
 
         final AnnotationItem annotationItem = resolveAnnotationItem();
 
@@ -77,42 +76,6 @@ public class GenerateActionListener implements ActionListener {
             messageService.onPluginExceptionHandled(exception);
         }
     }
-
-
-    /**
-     * Disable autovalue when select Kotlin
-     *
-     * @param languageItem The selected language item
-     */
-    private void changeAnnotation(LanguageItem languageItem) {
-
-        ButtonGroup                 buttonGroup = generatorVew.getTypeButtonGroup();
-        Enumeration<AbstractButton> buttons     = buttonGroup.getElements();
-
-        if (languageItem.equals(LanguageItem.KOTLIN_DTO)) {
-            while (buttons.hasMoreElements()) {
-                final AbstractButton button = buttons.nextElement();
-
-                if (button.getText().contains("AutoValue")) {
-                    button.setSelected(false);
-                    button.setEnabled(false);
-                }
-                else if (button.getText().equals(AnnotationItem.NONE.getText())) {
-                    button.setSelected(true);
-                }
-            }
-        }
-        else {
-            while (buttons.hasMoreElements()) {
-                final AbstractButton button = buttons.nextElement();
-
-                if (!button.isEnabled()) {
-                    button.setEnabled(true);
-                }
-            }
-        }
-    }
-
 
     private LanguageItem resolveLanguageItem() {
 

--- a/src/main/java/com/robohorse/robopojogenerator/listeners/GenerateActionListener.java
+++ b/src/main/java/com/robohorse/robopojogenerator/listeners/GenerateActionListener.java
@@ -1,22 +1,23 @@
 package com.robohorse.robopojogenerator.listeners;
 
-import com.intellij.codeInspection.javaDoc.JavadocHtmlLintAnnotator;
 import com.robohorse.robopojogenerator.errors.RoboPluginException;
 import com.robohorse.robopojogenerator.generator.consts.AnnotationItem;
 import com.robohorse.robopojogenerator.generator.consts.LanguageItem;
-import com.robohorse.robopojogenerator.generator.postprocessors.AbsPostProcessor;
 import com.robohorse.robopojogenerator.generator.utils.ClassGenerateHelper;
 import com.robohorse.robopojogenerator.injections.Injector;
 import com.robohorse.robopojogenerator.models.GenerationModel;
 import com.robohorse.robopojogenerator.services.MessageService;
 import com.robohorse.robopojogenerator.view.GeneratorVew;
 
-import javax.inject.Inject;
-import javax.swing.*;
-
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Enumeration;
+
+import javax.inject.Inject;
+import javax.swing.AbstractButton;
+import javax.swing.ButtonGroup;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
 
 /**
  * Created by vadim on 24.09.16.
@@ -63,14 +64,14 @@ public class GenerateActionListener implements ActionListener {
             classGenerateHelper.validateJsonContent(content);
             eventListener.onJsonDataObtained(new GenerationModel
                     .Builder()
-                                                     .setLanguageItem(languageItem)
-                                                     .setAnnotationItem(annotationItem)
-                                                     .setContent(content)
-                                                     .setSettersAvailable(useSetters)
-                                                     .setGettersAvailable(useGetters)
-                                                     .setRootClassName(className)
-                                                     .setRewriteClasses(rewriteClasses)
-                                                     .build());
+                    .setLanguageItem(languageItem)
+                    .setAnnotationItem(annotationItem)
+                    .setContent(content)
+                    .setSettersAvailable(useSetters)
+                    .setGettersAvailable(useGetters)
+                    .setRootClassName(className)
+                    .setRewriteClasses(rewriteClasses)
+                    .build());
 
         } catch (RoboPluginException exception) {
             messageService.onPluginExceptionHandled(exception);

--- a/src/main/java/com/robohorse/robopojogenerator/models/GenerationModel.java
+++ b/src/main/java/com/robohorse/robopojogenerator/models/GenerationModel.java
@@ -1,12 +1,14 @@
 package com.robohorse.robopojogenerator.models;
 
 import com.robohorse.robopojogenerator.generator.consts.AnnotationItem;
+import com.robohorse.robopojogenerator.generator.consts.LanguageItem;
 
 /**
  * Created by vadim on 28.09.16.
  */
 public class GenerationModel {
     private boolean rewriteClasses;
+    private LanguageItem languageItem;
     private AnnotationItem annotationItem;
     private String rootClassName;
     private String content;
@@ -37,6 +39,12 @@ public class GenerationModel {
         return useGetters;
     }
 
+
+    public LanguageItem getLanguageItem() {
+        return languageItem;
+    }
+
+
     public static class Builder {
         private GenerationModel instance;
 
@@ -46,6 +54,11 @@ public class GenerationModel {
 
         public Builder setRewriteClasses(boolean rewriteClasses) {
             instance.rewriteClasses = rewriteClasses;
+            return this;
+        }
+
+        public Builder setLanguageItem(LanguageItem languageItem) {
+            instance.languageItem = languageItem;
             return this;
         }
 

--- a/src/main/java/com/robohorse/robopojogenerator/services/FileWriterService.java
+++ b/src/main/java/com/robohorse/robopojogenerator/services/FileWriterService.java
@@ -4,6 +4,7 @@ import com.robohorse.robopojogenerator.errors.RoboPluginException;
 import com.robohorse.robopojogenerator.errors.custom.FileWriteException;
 import com.robohorse.robopojogenerator.generator.ClassItem;
 import com.robohorse.robopojogenerator.generator.PostProcessorFactory;
+import com.robohorse.robopojogenerator.generator.consts.LanguageItem;
 import com.robohorse.robopojogenerator.generator.postprocessors.AbsPostProcessor;
 import com.robohorse.robopojogenerator.models.GenerationModel;
 import com.robohorse.robopojogenerator.models.ProjectModel;
@@ -29,7 +30,15 @@ public class FileWriterService {
     public void writeFile(ClassItem classItem, GenerationModel generationModel,
                           ProjectModel projectModel) throws RoboPluginException {
         final String path = projectModel.getDirectory().getVirtualFile().getPath();
-        final String fileName = classItem.getClassName() + ".java";
+
+        final String fileName;
+        if (generationModel.getLanguageItem().equals(LanguageItem.KOTLIN_DTO)) {
+            fileName = classItem.getClassName() + ".kt";
+        }
+        else {
+            fileName = classItem.getClassName() + ".java";
+        }
+
         final File file = new File(path + File.separator + fileName);
         try {
             if (file.exists()) {

--- a/src/main/java/com/robohorse/robopojogenerator/services/FileWriterService.java
+++ b/src/main/java/com/robohorse/robopojogenerator/services/FileWriterService.java
@@ -4,6 +4,7 @@ import com.robohorse.robopojogenerator.errors.RoboPluginException;
 import com.robohorse.robopojogenerator.errors.custom.FileWriteException;
 import com.robohorse.robopojogenerator.generator.ClassItem;
 import com.robohorse.robopojogenerator.generator.PostProcessorFactory;
+import com.robohorse.robopojogenerator.generator.consts.AnnotationItem;
 import com.robohorse.robopojogenerator.generator.consts.LanguageItem;
 import com.robohorse.robopojogenerator.generator.postprocessors.AbsPostProcessor;
 import com.robohorse.robopojogenerator.models.GenerationModel;
@@ -32,7 +33,8 @@ public class FileWriterService {
         final String path = projectModel.getDirectory().getVirtualFile().getPath();
 
         final String fileName;
-        if (generationModel.getLanguageItem().equals(LanguageItem.KOTLIN_DTO)) {
+        if (generationModel.getLanguageItem().equals(LanguageItem.KOTLIN_DTO)
+                && !generationModel.getAnnotationItem().equals(AnnotationItem.AUTO_VALUE_GSON)) {
             fileName = classItem.getClassName() + ".kt";
         }
         else {

--- a/src/main/java/com/robohorse/robopojogenerator/view/GeneratorVew.form
+++ b/src/main/java/com/robohorse/robopojogenerator/view/GeneratorVew.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.robohorse.robopojogenerator.view.GeneratorVew">
-  <grid id="27dc6" binding="rootView" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="rootView" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="527" height="478"/>
+      <xy x="20" y="20" width="527" height="496"/>
     </constraints>
     <properties/>
     <border type="empty"/>
@@ -21,7 +21,7 @@
       <grid id="95dae" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="empty"/>
@@ -177,6 +177,33 @@
           </grid>
         </children>
       </grid>
+      <grid id="d9b41" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="e3dc" class="javax.swing.JRadioButton" binding="javaPojoButton">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <selected value="true"/>
+              <text value="Java POJO"/>
+            </properties>
+          </component>
+          <component id="6b2c" class="javax.swing.JRadioButton" binding="kotlinDtoButton">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Kotlin DTO"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
     </children>
   </grid>
   <buttonGroups>
@@ -191,6 +218,10 @@
       <member id="8b642"/>
       <member id="c4ca6"/>
       <member id="20088"/>
+    </group>
+    <group name="languageGroup" bound="true">
+      <member id="e3dc"/>
+      <member id="6b2c"/>
     </group>
   </buttonGroups>
 </form>

--- a/src/main/java/com/robohorse/robopojogenerator/view/GeneratorVew.form
+++ b/src/main/java/com/robohorse/robopojogenerator/view/GeneratorVew.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="rootView" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="527" height="496"/>
+      <xy x="20" y="20" width="527" height="506"/>
     </constraints>
     <properties/>
     <border type="empty"/>
@@ -36,43 +36,44 @@
             <children>
               <component id="8b642" class="javax.swing.JRadioButton" binding="NONERadioButton" default-binding="true">
                 <constraints>
-                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <text value="NONE"/>
-                </properties>
-              </component>
-              <component id="1db40" class="javax.swing.JRadioButton" binding="loganSquareRadioButton" default-binding="true">
-                <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <text value="Logan Square"/>
-                </properties>
-              </component>
-              <component id="aa398" class="javax.swing.JRadioButton" binding="GSONRadioButton" default-binding="true">
-                <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <selected value="true"/>
+                  <text value="NONE"/>
+                </properties>
+              </component>
+              <component id="aa398" class="javax.swing.JRadioButton" binding="GSONRadioButton" default-binding="true">
+                <constraints>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <selected value="false"/>
                   <text value="GSON"/>
                 </properties>
               </component>
               <component id="c4ca6" class="javax.swing.JRadioButton" binding="jackson2RadioButton">
                 <constraints>
-                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Jackson"/>
                 </properties>
               </component>
-              <component id="20088" class="javax.swing.JRadioButton" binding="radioButton1" default-binding="true">
+              <component id="1db40" class="javax.swing.JRadioButton" binding="loganSquareRadioButton" default-binding="true">
                 <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="RadioButton"/>
+                  <text value="Logan Square"/>
+                </properties>
+              </component>
+              <component id="20088" class="javax.swing.JRadioButton" binding="autoValueGsonButton">
+                <constraints>
+                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="AutoValue(GSON)"/>
                 </properties>
               </component>
             </children>
@@ -211,17 +212,16 @@
       <member id="e74b1"/>
       <member id="38ee8"/>
     </group>
-    <group name="typeButtonGroup" bound="true">
-      <member id="aa398"/>
-      <member id="1db40"/>
-      <member id="aab11"/>
-      <member id="8b642"/>
-      <member id="c4ca6"/>
-      <member id="20088"/>
-    </group>
     <group name="languageGroup" bound="true">
       <member id="e3dc"/>
       <member id="6b2c"/>
+    </group>
+    <group name="typeButtonGroup" bound="true">
+      <member id="8b642"/>
+      <member id="aa398"/>
+      <member id="c4ca6"/>
+      <member id="1db40"/>
+      <member id="20088"/>
     </group>
   </buttonGroups>
 </form>

--- a/src/main/java/com/robohorse/robopojogenerator/view/GeneratorVew.java
+++ b/src/main/java/com/robohorse/robopojogenerator/view/GeneratorVew.java
@@ -23,7 +23,7 @@ public class GeneratorVew {
     private JScrollPane  scrollView;
     private JCheckBox    useSettersCheckBox;
     private JCheckBox    useGettersCheckBox;
-    private JRadioButton radioButton1;
+    private JRadioButton autoValueGsonButton;
     private JRadioButton javaPojoButton;
     private JRadioButton kotlinDtoButton;
     private ButtonGroup languageGroup;

--- a/src/main/java/com/robohorse/robopojogenerator/view/GeneratorVew.java
+++ b/src/main/java/com/robohorse/robopojogenerator/view/GeneratorVew.java
@@ -12,19 +12,22 @@ import java.io.IOException;
  */
 public class GeneratorVew {
     private JPanel rootView;
-    private JButton generateButton;
+    private JButton         generateButton;
     private RSyntaxTextArea textArea;
     private JRadioButton NONERadioButton;
     private JRadioButton jackson2RadioButton;
     private JRadioButton loganSquareRadioButton;
     private JRadioButton GSONRadioButton;
-    private JCheckBox rewriteExistingClassesCheckBox;
-    private JTextField className;
-    private JScrollPane scrollView;
-    private JCheckBox useSettersCheckBox;
-    private JCheckBox useGettersCheckBox;
+    private JCheckBox    rewriteExistingClassesCheckBox;
+    private JTextField   className;
+    private JScrollPane  scrollView;
+    private JCheckBox    useSettersCheckBox;
+    private JCheckBox    useGettersCheckBox;
     private JRadioButton radioButton1;
-    private ButtonGroup typeButtonGroup;
+    private JRadioButton javaPojoButton;
+    private JRadioButton kotlinDtoButton;
+    private ButtonGroup languageGroup;
+    private ButtonGroup  typeButtonGroup;
 
     public JCheckBox getUseSettersCheckBox() {
         return useSettersCheckBox;
@@ -86,5 +89,11 @@ public class GeneratorVew {
         } catch (IOException ioe) {
             ioe.printStackTrace();
         }
+    }
+
+
+    public ButtonGroup getLanguageGroup() {
+
+        return languageGroup;
     }
 }

--- a/src/main/java/com/robohorse/robopojogenerator/view/GeneratorViewBinder.java
+++ b/src/main/java/com/robohorse/robopojogenerator/view/GeneratorViewBinder.java
@@ -1,6 +1,7 @@
 package com.robohorse.robopojogenerator.view;
 
 import com.intellij.openapi.ui.DialogBuilder;
+import com.robohorse.robopojogenerator.generator.consts.LanguageItem;
 import com.robohorse.robopojogenerator.listeners.GenerateActionListener;
 import com.robohorse.robopojogenerator.listeners.GuiFormEventListener;
 import com.robohorse.robopojogenerator.generator.consts.AnnotationItem;
@@ -27,6 +28,20 @@ public class GeneratorViewBinder {
         builder.setTitle("RoboPOJOGenerator");
         builder.removeAllActions();
         builder.show();
+    }
+
+    private void bindLanguageViews(ButtonGroup buttonGroup) {
+        final Enumeration<AbstractButton> buttons  = buttonGroup.getElements();
+
+        for (LanguageItem languageItem : LanguageItem.values()) {
+            if (buttons.hasMoreElements()) {
+                final AbstractButton button = buttons.nextElement();
+                button.setText(languageItem.getText());
+            }
+            else {
+                break;
+            }
+        }
     }
 
     private void bindGroupViews(ButtonGroup buttonGroup) {


### PR DESCRIPTION
Add Kotlin support to generate [Kotlin Data Classes](https://kotlinlang.org/docs/reference/data-classes.html)

Close #33 
Close https://github.com/wafer-li/RoboPOJOGenerator/issues/2
Close https://github.com/wafer-li/RoboPOJOGenerator/issues/3

Also support **Annotation**

Fix not using camelCase **ONLY** in my Kotlin support implementation

Fix annotation item radio button order in view form

Sorry, it takes me some extra time to fix bugs.

Screenshots:

![image](https://cloud.githubusercontent.com/assets/12459199/19633667/0f437990-99ef-11e6-99ab-cae0898dc81d.png)

![image](https://cloud.githubusercontent.com/assets/12459199/19633786/1f5a5dca-99f0-11e6-9e73-778faac05ca2.png)

With Annotation (GSON):

![image](https://cloud.githubusercontent.com/assets/12459199/19633930/6a73a8b0-99f1-11e6-990e-c3cfc86e8edc.png)


### Potential Problem

1. The camelCase is not using in other places

2. ~~Annotation support will get wrong when work with annotation name contains "@"~~
  
3. Not working for AutoValue
    > Actually, I am not familiar with Swing, I want to disable the AutoValue radio when click Kotlin
    > But I fail.
    > Therefore, when you select **Kotlin AND AutoValue**, It will actually generate the **Java** file

4. It is no way to change file name postfix with PostProccessor, so I change the postfix in `FileWriterService`, It might not elegant.