### PR TITLE
Fix update kotlin type

### DIFF
--- a/src/main/java/com/robohorse/robopojogenerator/generator/utils/ClassGenerateHelper.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/utils/ClassGenerateHelper.java
@@ -112,8 +112,8 @@ public class ClassGenerateHelper {
 
     public String updateKotlinType(String type) {
         if (type.contains("<")) {
-            type = type.replace(ClassType.OBJECT.getBoxed(), "Any");
-            type = type.replace(ClassType.INTEGER.getBoxed(), "Int");
+            type = type.replace("<" + ClassType.OBJECT.getBoxed() + ">", "<Any>");
+            type = type.replace("<" + ClassType.INTEGER.getBoxed() + ">", "<Int>");
             type = type.replace(">", "?>");
         } else if (type.equals("Object")) {
             return "Any";

--- a/src/main/java/com/robohorse/robopojogenerator/generator/utils/ClassGenerateHelper.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/utils/ClassGenerateHelper.java
@@ -112,11 +112,14 @@ public class ClassGenerateHelper {
 
     public String updateKotlinType(String type) {
         if (type.contains("<")) {
-            return type.replace(ClassType.OBJECT.getBoxed(), "Any")
-                    .replace(">", "?>");
-
+            type = type.replace(ClassType.OBJECT.getBoxed(), "Any");
+            type = type.replace(ClassType.INTEGER.getBoxed(), "Int");
+            type = type.replace(">", "?>");
         } else if (type.equals("Object")) {
             return "Any";
+        }
+        else {
+            type = upperCaseFirst(type);
         }
         return type;
     }

--- a/src/test/java/com/robohorse/robopojogenerator/generator/utils/ClassGenerateHelperTest.java
+++ b/src/test/java/com/robohorse/robopojogenerator/generator/utils/ClassGenerateHelperTest.java
@@ -1,11 +1,13 @@
 package com.robohorse.robopojogenerator.generator.utils;
 
 import com.robohorse.robopojogenerator.errors.RoboPluginException;
-import com.robohorse.robopojogenerator.generator.utils.ClassGenerateHelper;
 import com.robohorse.robopojogenerator.models.InnerArrayModel;
+
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Created by vadim on 28.09.16.
@@ -90,5 +92,25 @@ public class ClassGenerateHelperTest {
 
         innerArrayModel.setMajorType(type);
         assertEquals(type, classGenerateHelper.resolveMajorType(innerArrayModel));
+    }
+
+    @Test
+    public void testUpdateKotlinType() throws Exception {
+        final String nestedListType = "List<List<List<Integer>>>";
+        final String nestedListTarget = "List<List<List<Int?>?>?>";
+
+        final String nestedListObjectType = "List<List<Object>>";
+        final String nestedListObjectTarget = "List<List<Any?>?>";
+
+        final String primitiveType = "int";
+        final String primitiveTarget = "Int";
+
+        final String objectType = "Object";
+        final String objectTarget = "Any";
+
+        assertEquals(nestedListTarget, classGenerateHelper.updateKotlinType(nestedListType));
+        assertEquals(nestedListObjectTarget, classGenerateHelper.updateKotlinType(nestedListObjectType));
+        assertEquals(primitiveTarget, classGenerateHelper.updateKotlinType(primitiveType));
+        assertEquals(objectTarget, classGenerateHelper.updateKotlinType(objectType));
     }
 }

--- a/src/test/java/com/robohorse/robopojogenerator/generator/utils/ClassGenerateHelperTest.java
+++ b/src/test/java/com/robohorse/robopojogenerator/generator/utils/ClassGenerateHelperTest.java
@@ -102,6 +102,12 @@ public class ClassGenerateHelperTest {
         final String nestedListObjectType = "List<List<Object>>";
         final String nestedListObjectTarget = "List<List<Any?>?>";
 
+        final String nestedListObjectItemType = "List<List<ObjectItem>>";
+        final String nestedListObjectItemTarget = "List<List<ObjectItem?>?>";
+
+        final String nestedListIntegerItemType = "List<List<IntegerItem>>";
+        final String nestedListIntegerItemTarget = "List<List<IntegerItem?>?>";
+
         final String primitiveType = "int";
         final String primitiveTarget = "Int";
 
@@ -110,6 +116,8 @@ public class ClassGenerateHelperTest {
 
         assertEquals(nestedListTarget, classGenerateHelper.updateKotlinType(nestedListType));
         assertEquals(nestedListObjectTarget, classGenerateHelper.updateKotlinType(nestedListObjectType));
+        assertEquals(nestedListObjectItemTarget, classGenerateHelper.updateKotlinType(nestedListObjectItemType));
+        assertEquals(nestedListIntegerItemTarget, classGenerateHelper.updateKotlinType(nestedListIntegerItemType));
         assertEquals(primitiveTarget, classGenerateHelper.updateKotlinType(primitiveType));
         assertEquals(objectTarget, classGenerateHelper.updateKotlinType(objectType));
     }


### PR DESCRIPTION
`Integer` -> `Int`
`Object` -> `Any`

`IntegerItem` and `ObjectItem` don't change

`int` -> `Int`
`double` -> `Double`
`long` -> `Long`
etc.

I also add a test for it.