### PR TITLE
Preserve fields across "cousin" objects

### DIFF
--- a/src/main/java/com/robohorse/robopojogenerator/generator/processing/ClassProcessor.java
+++ b/src/main/java/com/robohorse/robopojogenerator/generator/processing/ClassProcessor.java
@@ -126,7 +126,15 @@ public class ClassProcessor {
                         proceed(jsonItem, innerItemsMap);
                     }
                     classField.setClassField(new ClassField(null, itemName));
-                    itemMap.putAll(innerItemsMap);
+                    innerItemsMap.forEach((key, value) -> {
+                        ClassItem existing = itemMap.get(key);
+                        if (existing != null) {
+                            value.getClassFields().forEach((classKey, classValue) -> existing.getClassFields().putIfAbsent(classKey, classValue));
+                            existing.getClassImports().addAll(value.getClassImports());
+                        } else {
+                            itemMap.put(key, value);
+                        }
+                    });
                 }
 
                 @Override

--- a/src/test/kotlin/com/robohorse/robopojogenerator/generator/processing/ClassProcessorTest.kt
+++ b/src/test/kotlin/com/robohorse/robopojogenerator/generator/processing/ClassProcessorTest.kt
@@ -139,4 +139,21 @@ class ClassProcessorTest {
             }
         }
     }
+
+    @Test
+    fun testNestedArrayElementsConsolidateObjectProperties() {
+        val jsonObject = jsonReader.read("nested_array_elements.json") as JSONObject
+        val name = "Response"
+        val classItemMap: Map<String, ClassItem> = HashMap()
+        val jsonItem = JsonItem(name, jsonObject)
+        classProcessor.proceed(jsonItem, classItemMap)
+        assertTrue(classItemMap.size == 1)
+        val classFields = classItemMap.values.firstOrNull()?.classFields
+        assertNotNull(classFields)
+        // when using "itemMap.putAll(innerItemsMap);" element "C" will be missing as newer instances of objects in
+        // innerItemsMap of the same name/type overwrite existing map (itemMap) entries
+        listOf("Outsides", "Outside", "Insides", "Inside", "A", "B", "C").listIterator().forEach {
+            assertTrue(classFields.containsKey(it), "Missing element: $it")
+        }
+    }
 }

--- a/src/test/resources/nested_array_elements.json
+++ b/src/test/resources/nested_array_elements.json
@@ -1,0 +1,29 @@
+{
+  "Outsides": [
+    {
+      "Outside": {
+        "Insides": [
+          {
+            "Inside": {
+              "A": "value",
+              "B": "value",
+              "C": "value"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "Outside": {
+        "Insides": [
+          {
+            "Inside": {
+              "A": "value2",
+              "B": "value2"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Instead of displacing object in itemMap, append fields and imports to existing entries.