### PR TITLE
Fix jitpack build by adding jitpack.yml and use jdk 11

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
Added jitpack.yml and used jdk 11 so fix jitpack build.

The full log of the build failure is here:
```https://jitpack.io/com/github/robohorse/RoboPOJOGenerator/2.3.8/build.log```