### PR TITLE
Add missing required 'maven-publish' plugin for jitpack build.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,12 +7,14 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version "1.6.0" apply false
     id("org.jetbrains.intellij") version "1.11.0"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
+    id("maven-publish")
 }
 
 subprojects {
     apply(plugin = "java")
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "org.jetbrains.intellij")
+    apply(plugin = "maven-publish")
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
A subsequent change to PR #137, to fix jitpack build.

The build has progressed due to PR #137, but it still fails. The logs are here:
```https://jitpack.io/com/github/robohorse/RoboPOJOGenerator/2.3.9/build.log```

After some further investigation, "maven-publish" plugin was required to be added to ```build.gradle.kts```.

@robohorse Could you please verify this before merging it? You can login at https://jitci.com/ and try and building the branch . Many thanks!

